### PR TITLE
Add minimal Kalshi v1 client

### DIFF
--- a/kalshi-v1/.env.example
+++ b/kalshi-v1/.env.example
@@ -1,0 +1,9 @@
+BASE_URL=https://demo-api.kalshi.co
+API_KEY_ID=YOUR_KEY_ID
+PRIVATE_KEY_PATH=/absolute/path/to/kalshi.key
+
+# Optional
+SIDE=yes              # yes | no
+PRICE_CENTS=1         # 1..99
+COUNT=1               # integer
+TIME_IN_FORCE=        # empty | fill_or_kill | immediate_or_cancel

--- a/kalshi-v1/README.md
+++ b/kalshi-v1/README.md
@@ -1,0 +1,18 @@
+# kalshi-v1
+
+Minimal CLI to place and verify a single limit order on the Kalshi REST v2 Demo API.
+
+## Quickstart
+
+1. Generate a Demo API key and RSA private key from Kalshi.
+2. Save the private key to a file and note the API key id.
+3. Copy `.env.example` to `.env` and fill `BASE_URL`, `API_KEY_ID`, and `PRIVATE_KEY_PATH`.
+4. Optional overrides: `SIDE` (`yes` or `no`), `PRICE_CENTS` (`1..99`), `COUNT` (integer), `TIME_IN_FORCE` (`fill_or_kill` or `immediate_or_cancel`).
+5. Install dependencies: `pip install -r requirements.txt`.
+6. Run the script: `python place_and_verify.py`.
+
+The program prints the selected ticker, created `order_id`, verification status, and queue positions if available.
+
+## Verification
+
+The script verifies that the server order fields exactly match the request for `ticker`, `side`, `action`, `type`, and the chosen price field. When both `filled_count` and `remaining_count` are present, it also checks `filled_count + remaining_count == requested count` to ensure quantity conservation.

--- a/kalshi-v1/kalshi_client.py
+++ b/kalshi-v1/kalshi_client.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+import base64
+import time
+import requests
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import serialization
+
+
+@dataclass
+class KalshiConfig:
+    base_url: str
+    api_key_id: str
+    private_key_path: str
+
+
+class KalshiClient:
+    def __init__(self, cfg: KalshiConfig):
+        self.cfg = cfg
+        with open(cfg.private_key_path, "rb") as fh:
+            self._key = serialization.load_pem_private_key(fh.read(), password=None)
+
+    def _sign(self, ts: str, method: str, path: str) -> str:
+        message = f"{ts}{method}{path}".encode()
+        signature = self._key.sign(
+            message,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+        return base64.b64encode(signature).decode()
+
+    def _request(self, method: str, path: str, **kwargs):
+        ts = str(int(time.time() * 1000))
+        method_up = method.upper()
+        signature = self._sign(ts, method_up, path)
+        headers = {
+            "KALSHI-ACCESS-KEY": self.cfg.api_key_id,
+            "KALSHI-ACCESS-TIMESTAMP": ts,
+            "KALSHI-ACCESS-SIGNATURE": signature,
+        }
+        url = self.cfg.base_url.rstrip("/") + path
+        return requests.request(method_up, url, headers=headers, timeout=10, **kwargs)
+
+    def get(self, path: str, params=None):
+        return self._request("GET", path, params=params)
+
+    def post(self, path: str, json=None):
+        return self._request("POST", path, json=json)

--- a/kalshi-v1/place_and_verify.py
+++ b/kalshi-v1/place_and_verify.py
@@ -1,0 +1,79 @@
+import os
+import sys
+import json
+import uuid
+from dotenv import load_dotenv
+from kalshi_client import KalshiClient, KalshiConfig
+
+
+def main():
+    load_dotenv()
+    base_url = os.getenv("BASE_URL")
+    api_key_id = os.getenv("API_KEY_ID")
+    key_path = os.getenv("PRIVATE_KEY_PATH")
+    if not all([base_url, api_key_id, key_path]):
+        sys.exit("Missing BASE_URL, API_KEY_ID, or PRIVATE_KEY_PATH")
+
+    cfg = KalshiConfig(base_url=base_url, api_key_id=api_key_id, private_key_path=key_path)
+    client = KalshiClient(cfg)
+
+    # Step 1: select an open market
+    r = client.get("/trade-api/v2/markets", params={"status": "open", "limit": 1})
+    if r.status_code != 200:
+        sys.exit(f"Market fetch failed: {r.status_code} {r.text}")
+    markets = r.json().get("markets", [])
+    if not markets:
+        sys.exit("No open markets returned")
+    ticker = markets[0]["ticker"]
+    print(f"Selected market ticker: {ticker}")
+
+    # Step 2: build order request
+    side = os.getenv("SIDE", "yes")
+    price_cents = int(os.getenv("PRICE_CENTS", "1"))
+    count = int(os.getenv("COUNT", "1"))
+    tif = os.getenv("TIME_IN_FORCE") or None
+    price_field = "yes_price" if side == "yes" else "no_price"
+    body = {
+        "ticker": ticker,
+        "action": "buy",
+        "side": side,
+        "count": count,
+        "type": "limit",
+        price_field: price_cents,
+        "client_order_id": str(uuid.uuid4()),
+    }
+    if tif:
+        body["time_in_force"] = tif
+
+    # Step 3: create order
+    r = client.post("/trade-api/v2/portfolio/orders", json=body)
+    if r.status_code != 201:
+        sys.exit(f"Order creation failed: {r.status_code} {r.text}")
+    order_id = r.json()["order"]["order_id"]
+    print(f"Created order_id: {order_id}")
+
+    # Step 4: fetch and verify
+    r = client.get(f"/trade-api/v2/portfolio/orders/{order_id}")
+    if r.status_code != 200:
+        sys.exit(f"Order fetch failed: {r.status_code} {r.text}")
+    order = r.json().get("order", {})
+    for field in ["ticker", "side", "action", "type"]:
+        if order.get(field) != body[field]:
+            sys.exit(f"Mismatch for {field}")
+    if order.get(price_field) != body[price_field]:
+        sys.exit(f"Mismatch for {price_field}")
+    filled = order.get("filled_count")
+    remaining = order.get("remaining_count")
+    if filled is not None and remaining is not None:
+        if filled + remaining != count:
+            sys.exit("Quantity conservation failed")
+    print("\u2705 Request matches server order fields.")
+
+    # Step 5: queue positions (best effort)
+    r = client.get("/trade-api/v2/portfolio/orders/queue_positions")
+    if r.status_code == 200:
+        print(json.dumps(r.json(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/kalshi-v1/requirements.txt
+++ b/kalshi-v1/requirements.txt
@@ -1,0 +1,3 @@
+requests
+cryptography
+python-dotenv

--- a/kalshi-v1/tests/acceptance_order.json
+++ b/kalshi-v1/tests/acceptance_order.json
@@ -1,0 +1,9 @@
+{
+  "goal": "Place a limit order and verify server fields strictly match the request",
+  "must_equal": ["ticker", "side", "action", "type", "price_field"],
+  "quantity_conservation": "filled_count + remaining_count == requested_count (when both are present)",
+  "notes": [
+    "Server-generated fields (order_id, timestamps, status) are excluded from exact-equality checks",
+    "Use client_order_id for idempotent retries"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement minimal Kalshi REST v2 client
- add CLI to place and verify a limit order on Demo

## Testing
- `python -m py_compile kalshi-v1/kalshi_client.py kalshi-v1/place_and_verify.py`
- `python -m json.tool kalshi-v1/tests/acceptance_order.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_689d41e8edd0832fa4514e7342dc514d